### PR TITLE
Fix Deno 2.8 timeout handle type

### DIFF
--- a/src/bot.ts
+++ b/src/bot.ts
@@ -704,7 +704,7 @@ async function withRetries<T>(
  * rejects as soon as the given signal is aborted.
  */
 async function sleep(seconds: number, signal?: AbortSignal) {
-    let handle: number | undefined;
+    let handle: ReturnType<typeof setTimeout> | undefined;
     let reject: ((err: Error) => void) | undefined;
     function abort() {
         reject?.(new Error("Aborted delay"));

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -718,7 +718,7 @@ async function sleep(seconds: number, signal?: AbortSignal) {
                 return;
             }
             signal?.addEventListener("abort", abort);
-            handle = setTimeout(res, 1000 * seconds);
+            handle = setTimeout(() => res(), 1000 * seconds);
         });
     } finally {
         signal?.removeEventListener("abort", abort);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the timeout handle type in `sleep()` for Deno 2.8 and wraps the timeout resolver to satisfy TypeScript. Uses `ReturnType<typeof setTimeout>` and `() => res()` to avoid type errors across Deno and Node, with no behavior change.

<sup>Written for commit 66fbbab0a601aae759225c4e9782bc493e7589ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/KnightNiwrem/grammY/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type safety in the retry mechanism by correcting a timeout type assumption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->